### PR TITLE
URI encoding parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports.requestHooks = [
       }
 
       while (path.includes(toReplace)) {
-        path = path.replace(toReplace, value);
+        path = path.replace(toReplace, encodeURIComponent(value));
       }
       url.pathname = path;
       context.request.removeParameter(name);


### PR DESCRIPTION
Query parameters are automatically encoded by insomnia to escape some special characters.
This change mimics the behaviour.

Example:
`project=someOrganization/someRepository`
`id=42`
`https://api.gitlab.com/v4/:project/:id`
Produces
=> `https://api.gitlab.com/v4/someOrganization/someRepository/42`
Instead of
=>  `https://api.gitlab.com/v4/someOrganization%2FsomeRepository/42`