### PR TITLE
Add ability to replace param in hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Npm Version](https://img.shields.io/npm/v/insomnia-plugin-path-parameters.svg)](https://www.npmjs.com/package/insomnia-plugin-path-parameters)
 
 This is a plugin for [Insomnia](https://insomnia.rest) that automatically replaces URL path
-parameters with syntax `:myParam` with values defined in the Query tab by the same name.
+parameters with syntax `:myParam` and the URL hostname (full or partial) with syntax `--myParam` with values defined in the Query tab by the same name.
 
 ## Installation
 
@@ -11,7 +11,8 @@ Install the `insomnia-plugin-path-parameters` plugin from Preferences > Plugins.
 
 ## Usage
 
-1. Add placeholders to url (eg. `https://example.com/:foo/:bar`)
-2. Add matching entries to Query tab (eg. `foo`, `bar`)
+1. Add placeholders to url hostname (eg. `https://--foo.example.com/`)
+2. Add placeholders to url path (eg. `https://--foo.example.com/:bar/:baz`)
+3. Add matching entries to Query tab (eg. `foo`, `bar`, `baz`)
 
 ![image](https://user-images.githubusercontent.com/587576/77125299-a2153880-6a02-11ea-80aa-75f7a937fcbb.png)

--- a/index.js
+++ b/index.js
@@ -6,7 +6,14 @@ module.exports.requestHooks = [
     for (const { name, value } of context.request.getParameters().sort((a, b) => b.name.length - a.name.length)) {
       if (!name) continue;
       
-      const toReplace = `:${name}`;
+      // First check the hostname for replacements
+      let toReplace = `--${name}`
+
+      if (url.hostname.includes(toReplace)) {
+        url.hostname = url.hostname.replace(toReplace, value);
+      }
+
+      toReplace = `:${name}`;
       let path = url.pathname;
 
       if (!path.includes(toReplace)) {
@@ -15,9 +22,10 @@ module.exports.requestHooks = [
       }
 
       while (path.includes(toReplace)) {
-        path = path.replace(toReplace, encodeURIComponent(value));
+        path = path.replace(toReplace, value);
       }
       url.pathname = path;
+
       context.request.removeParameter(name);
     }
 

--- a/index.js
+++ b/index.js
@@ -7,16 +7,24 @@ module.exports.requestHooks = [
       if (!name) continue;
       
       // First check the hostname for replacements
-      let toReplace = `--${name}`
+      let toReplace = `--${name}`;
+      let hostnameReplaced = false;
 
       if (url.hostname.includes(toReplace)) {
         url.hostname = url.hostname.replace(toReplace, value);
+
+        hostnameReplaced = true;
       }
 
       toReplace = `:${name}`;
       let path = url.pathname;
 
       if (!path.includes(toReplace)) {
+        if (hostnameReplaced === true) {
+          // Not found in the pathname but was in the hostname
+          context.request.removeParameter(name);
+        }
+
         // Not found in URL, treat as regular parameter
         continue;
       }


### PR DESCRIPTION
Thanks for the plugin. It's been very helpful.

I'm submitting this update that will allow for query replacements to also apply to the hostname. 

I use an API that fetches info from the blockchain. It supports multiple networks and testnets. To target the different networks you have to call different subdomains.

I'm not sure if the hostname replacement pattern is the best. I was limited on characters to use because you cannot create a URL object with invalid characters. I considered `--param--` instead and found `--param` was sufficient for me. Some input from others who would use this feature would be helpful.

Thanks